### PR TITLE
use github pages data file feature and front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official source repository of [**ShittySomething.com**](http://shitt
 
 1. **Fork** the repository
 2. Create a **Branch**
-3. Open the **index.html** file, search for **carousel** class and put the new phrase at the top of others
+3. Open the **_data/quotes.yml** file and put a new quote at the top
 4. Make a **Pull Request**
 5. Wait for the **Review**
 6. **Share** and **enjoy** your mood at [ShittySomething.com](http://shittysomething.com/)

--- a/_data/quotes.yml
+++ b/_data/quotes.yml
@@ -1,0 +1,11 @@
+- You feel like a shitty coder when you spend an entire day provisioning your ec2 instance<br>and you realize <i>"its all about security groups"</i>
+- You feel like a shitty coder when you say <i>"I have never touched this code"</i><br/>but git blame states the opposite
+- You feel like a shitty coder when somebody pushes a ton of commits<br/>and you need git bisect to figure out where things break
+- You feel like a shitty coder when you say&colon; <i>"it worked on my machine"</i>
+- You feel like a shitty coder when you mess up a git rebase,<br/> force push to master and apologize to your colleagues
+- You feel like a shitty coder when you push changes before leaving the office<br/>and you break the continuous integration
+- You feel like a shitty coder when your manager<br/>tells you to do your work <i>"quick and dirty"</i>
+- You feel like a shitty coder when you do a huge refactoring<br/>and one of your colleagues destroys everything the very day after
+- You feel like a shitty coder when you don't refactor a chain of ifs<br/>because you know nobody will appreciate it
+- You feel like a shitty coder when you git pull --rebase<br/>instead of git rebase
+- You feel like a shitty coder when somebody breaks an interface<br/>and you say&colon; <i>"I won't touch this shit"</i>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -15,19 +18,8 @@
     <p class="front-image">
       <img src="assets/shittycoder.png" />
     </p>
-    <div class="carousel">
-      <div>You feel like a shitty coder when you spend an entire day provisioning your ec2 instance<br>and you realize <i>"its all about security groups"</i></div>
-      <div>You feel like a shitty coder when you say <i>"I have never touched this code"</i><br/>but git blame states the opposite</div>
-      <div>You feel like a shitty coder when somebody pushes a ton of commits<br/>and you need git bisect to figure out where things break</div>
-      <div>You feel like a shitty coder when you say: <i>"it worked on my machine"</i></div>
-      <div>You feel like a shitty coder when you mess up a git rebase,<br/> force push to master and apologize to your colleagues</div>
-      <div>You feel like a shitty coder when you push changes before leaving the office<br/>and you break the continuous integration</div>
-      <div>You feel like a shitty coder when your manager<br/>tells you to do your work <i>"quick and dirty"</i></div>
-      <div>You feel like a shitty coder when you do a huge refactoring<br/>and one of your colleagues destroys everything the very day after</div>
-      <div>You feel like a shitty coder when you don't refactor a chain of ifs<br/>because you know nobody will appreciate it</div>
-      <div>You feel like a shitty coder when you git pull --rebase<br/>instead of git rebase</div>
-      <div>You feel like a shitty coder when somebody breaks an interface<br/>and you say: <i>"I won't touch this shit"</i></div>
-    </div>
+    <div class="carousel">{% for quote in site.data.quotes %}
+      <div>{{ quote }}</div>{% endfor %}</div>
     <p class="navigation">
       <button type="button" class="slick-prev"></button><button type="button" class="slick-next"></button>
     </p>


### PR DESCRIPTION
This adds new README instructions on how to contribute with the usage of Github pages data files.

The quotes are stored in `_data/quotes.yml`, and are rendered with Liquid templates in `index.html` in a for loop.

Adding a quote is as simple as adding a line to `_data/quotes.yml`.

Enjoy,
Christian :)